### PR TITLE
feat(invoices): raise an InvoiceEvent before and after invoice save

### DIFF
--- a/src/events/ContactEvent.php
+++ b/src/events/ContactEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace thejoshsmith\commerce\xero\events;
+
+use craft\commerce\elements\Order;
+use thejoshsmith\commerce\xero\services\XeroAPI;
+use XeroPHP\Models\Accounting\Contact;
+use yii\base\Event;
+
+/**
+ * A Contact event
+ */
+class ContactEvent extends Event
+{
+    /**
+     * Contact Model
+     *
+     * @var Contact
+     */
+    public $contact;
+
+    /**
+     * Order Element
+     *
+     * @var Order
+     */
+    public $order;
+
+    /**
+     * XeroApi
+     *
+     * @var XeroAPI
+     */
+    public $xero;
+}

--- a/src/events/InvoiceEvent.php
+++ b/src/events/InvoiceEvent.php
@@ -3,8 +3,8 @@
 namespace thejoshsmith\commerce\xero\events;
 
 use craft\commerce\elements\Order;
-use thejoshsmith\commerce\xero\models\Invoice;
 use thejoshsmith\commerce\xero\services\XeroAPI;
+use XeroPHP\Models\Accounting\Invoice;
 use yii\base\Event;
 
 /**

--- a/src/events/InvoiceEvent.php
+++ b/src/events/InvoiceEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace thejoshsmith\commerce\xero\events;
+
+use craft\commerce\elements\Order;
+use thejoshsmith\commerce\xero\models\Invoice;
+use thejoshsmith\commerce\xero\services\XeroAPI;
+use yii\base\Event;
+
+/**
+ * An Invoice event
+ */
+class InvoiceEvent extends Event
+{
+    /**
+     * Contact Model
+     *
+     * @var Invoice
+     */
+    public $invoice;
+
+    /**
+     * Order Element
+     *
+     * @var Order
+     */
+    public $order;
+
+    /**
+     * XeroApi
+     *
+     * @var XeroAPI
+     */
+    public $xero;
+}

--- a/src/events/LineItemEvent.php
+++ b/src/events/LineItemEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace thejoshsmith\commerce\xero\events;
+
+use craft\commerce\models\LineItem as LineItemModel;
+use XeroPHP\Models\Accounting\LineItem;
+use thejoshsmith\commerce\xero\services\XeroAPI;
+use yii\base\Event;
+
+/**
+ * An Invoice event
+ */
+class LineItemEvent extends Event
+{
+    /**
+     * Contact Model
+     *
+     * @var LineItem
+     */
+    public $lineItem;
+
+    /**
+     * Order Element
+     *
+     * @var LineItemModel
+     */
+    public $orderItem;
+
+    /**
+     * XeroApi
+     *
+     * @var XeroAPI
+     */
+    public $xero;
+}


### PR DESCRIPTION
@thejoshsmith We needed the ability to hook in and add some additional data to contacts and invoices when saving. I saw the todos in there so thought I'd have a crack and send through a PR.

Is this what you had in mind? Am I missing anything?